### PR TITLE
Revamp Dockerfile to actually use build, use Caddy for URL env var template to get right URL at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ output/
 *.swp
 frontend/node_modules/
 frontend/package-lock.json
+node_modules
+dist

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,6 @@
+:80
+
+root * /usr/share/caddy
+file_server
+
+templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM node:14
-
+FROM node:20-alpine as build
 WORKDIR /app
-
-COPY package.json package.json
-RUN npm install
-
+COPY package.json .
+COPY package-lock.json .
+# CI builds only the dependencies in the lockfile, this ensures build is reproducible
+RUN npm ci
 COPY . .
-EXPOSE 3000
-CMD npm run dev
+RUN npm run build
+
+# We use a multi-stage build to make the final version
+FROM caddy:2.8-alpine
+
+# Copy a custom Caddyfile
+COPY Caddyfile /etc/caddy/Caddyfile
+# Copy the build output to Caddy's web root
+COPY --from=build /app/dist /usr/share/caddy
+
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # app
-The application has a frontend and a service, which can, but do not have to, be implemented separately. The application uses the model service in a sensible use case.
+This is the frontend to the backend in app-service. It allows you to run the model from a simple web page. It only supports a single URL for now.
 
-• Depends on the lib-version through a package manager (e.g., Maven). The version is visible in the frontend.
-
-• Queries the model-service through REST requests.
-
-• The URL of the model-service is configurable as an environment variable.
-
-
-## Usage
+## Local development
 
 ```
-
 docker build -t frontend .
-
-docker run -dp 3000:3000 --rm frontend
+# -d runs it in detached mode, -p sets the port to localhost:3000 and --rm makes sure it's deleted after being stopped, frontend is the tag
+docker run -d -p 3000:80 --rm frontend
 ```
 
+## Run production version
 
+The CI builds the image with name `ghcr.io/remla24-team8/app-frontend`.
+
+You can pull the latest development version with `docker pull ghcr.io/remla24-team8/app-frontend:main`. When you make a release, it also creates a tagged version, so e.g. `ghcr.io/remla24-team8/app-frontend:v0.1.0`. 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
 </head>
 <body>
   <div id="root"></div>
+  <script>
+    // Below uses a Caddy template (in between the curly brackets), so it is replaced by Caddy by the value of the environment variable
+    window.BACKEND_URL = "{{env "BACKEND_URL"}}";
+  </script>
   <script type="module" src="/src/index.jsx"></script>
 </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,23 +1,25 @@
 import React, { useState, useEffect } from 'react';
 
+const BACKEND_URL = window.BACKEND_URL ?? 'http://localhost:5001'
+
 function App() {
   const [version, setVersion] = useState('');
   const [prediction, setPrediction] = useState(null);
   const [inputData, setInputData] = useState('');
 
   useEffect(() => {
-    fetch('/api/version')
+    fetch(`${BACKEND_URL}/version`)
       .then(response => response.json())
       .then(data => setVersion(data.version));
   }, []);
 
   const handlePredict = () => {
-    fetch('/api/predict', {
+    fetch(`${BACKEND_URL}/predict`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ input: inputData })
+      body: JSON.stringify({ url: inputData })
     })
       .then(response => response.json())
       .then(data => setPrediction(data));

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,12 +6,5 @@ export default defineConfig({
   server: {
     host: true,
     port: 3000,  // Ensure this port is not in use
-    proxy: {
-      '/api': {
-        target: 'http://app-backend:5000',
-        changeOrigin: true,
-        secure: false,
-      }
-    }
   }
 });


### PR DESCRIPTION
* Moves from running the Vite dev server to using Vite to build and then run using a static file server using Caddy (similar to nginx/apache)
* To still be able to change the URL where the backend is at runtime, I used the Caddy template function to read an environment variable and modify the HTML
* I use a multi-stage build, first build it using the (much larger) node image and then we only need the output and the small Caddy image to run it